### PR TITLE
FEATURE: PCI-274 Implement Token Flush via keystone-manage.

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -782,6 +782,19 @@ example::
     $ keystone service-delete 08741d8ed88242ca88d1f61484a0fe3b
 
 
+
+Removing Expired Tokens
+===========================================================
+
+In the SQL and KVS token stores expired tokens are not automatically
+removed. These tokens can be removed with::
+
+    $ keystone-manage token_flush
+
+The memcache backend automatically discards expired tokens and so flushing
+is unnecessary and if attempted will fail with a NotImplemented error.
+
+
 Configuring the LDAP Identity Provider
 ===========================================================
 

--- a/doc/source/man/keystone-manage.rst
+++ b/doc/source/man/keystone-manage.rst
@@ -47,6 +47,8 @@ Available commands:
 * ``export_legacy_catalog``: Export the service catalog from a legacy database.
 * ``import_legacy``: Import a legacy database.
 * ``import_nova_auth``: Import a dump of nova auth data into keystone.
+* ``pki_setup``: Initialize the certificates used to sign tokens.
+* ``token_flush``: Purge expired tokens.
 
 OPTIONS
 =======

--- a/keystone/cli.py
+++ b/keystone/cli.py
@@ -23,6 +23,7 @@ from keystone import config
 from keystone.common import openssl
 from keystone.openstack.common import importutils
 from keystone.openstack.common import jsonutils
+from keystone import token
 
 CONF = config.CONF
 
@@ -67,6 +68,17 @@ class PKISetup(BaseApp):
     def main(self):
         conf_ssl = openssl.ConfigurePKI()
         conf_ssl.run()
+
+
+class TokenFlush(BaseApp):
+    """Flush expired tokens from the backend."""
+
+    name = 'token_flush'
+
+    @classmethod
+    def main(cls):
+        token_manager = token.Manager()
+        token_manager.driver.flush_expired_tokens()
 
 
 class ImportLegacy(BaseApp):
@@ -125,6 +137,7 @@ CMDS = {'db_sync': DbSync,
         'export_legacy_catalog': ExportLegacyCatalog,
         'import_nova_auth': ImportNovaAuth,
         'pki_setup': PKISetup,
+        'token_flush': TokenFlush,
         }
 
 

--- a/keystone/token/backends/kvs.py
+++ b/keystone/token/backends/kvs.py
@@ -82,3 +82,9 @@ class Token(kvs.Base, token.Driver):
             record['expires'] = token_ref['expires']
             tokens.append(record)
         return tokens
+
+    def flush_expired_tokens(self):
+        now = timeutils.utcnow()
+        for token, token_ref in self.db.items():
+            if self.is_expired(now, token_ref):
+                self.db.delete(token)

--- a/keystone/token/backends/sql.py
+++ b/keystone/token/backends/sql.py
@@ -130,3 +130,12 @@ class Token(sql.Base, token.Driver):
             }
             tokens.append(record)
         return tokens
+
+    def flush_expired_tokens(self):
+        session = self.get_session()
+
+        query = session.query(TokenModel)
+        query = query.filter(TokenModel.expires < timeutils.utcnow())
+        query.delete(synchronize_session=False)
+
+        session.flush()

--- a/keystone/token/core.py
+++ b/keystone/token/core.py
@@ -15,7 +15,6 @@
 # under the License.
 
 """Main entry point into the Token service."""
-
 import datetime
 
 from keystone.common import manager
@@ -131,3 +130,8 @@ class Driver(object):
         """
         expire_delta = datetime.timedelta(seconds=CONF.token.expiration)
         return timeutils.utcnow() + expire_delta
+
+    def flush_expired_tokens(self):
+        """Archive or delete tokens that have expired.
+        """
+        raise exception.NotImplemented()

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -758,6 +758,32 @@ class TokenTests(object):
         self.check_list_revoked_tokens([self.delete_token()
                                         for x in xrange(2)])
 
+    def test_flush_expired_token(self):
+        token_id = uuid.uuid4().hex
+        expire_time = timeutils.utcnow() - datetime.timedelta(minutes=1)
+        data = {'id_hash': token_id, 'id': token_id, 'a': 'b',
+                'expires': expire_time,
+                'trust_id': None,
+                'user': {'id': 'testuserid'}}
+        data_ref = self.token_api.create_token(token_id, data)
+        data_ref.pop('user_id')
+        self.assertDictEqual(data_ref, data)
+
+        token_id = uuid.uuid4().hex
+        expire_time = timeutils.utcnow() + datetime.timedelta(minutes=1)
+        data = {'id_hash': token_id, 'id': token_id, 'a': 'b',
+                'expires': expire_time,
+                'trust_id': None,
+                'user': {'id': 'testuserid'}}
+        data_ref = self.token_api.create_token(token_id, data)
+        data_ref.pop('user_id')
+        self.assertDictEqual(data_ref, data)
+
+        self.token_api.flush_expired_tokens()
+        tokens = self.token_api.list_tokens('testuserid')
+        self.assertEqual(len(tokens), 1)
+        self.assertIn(token_id, tokens)
+
 
 class CommonHelperTests(test.TestCase):
     def test_format_helper_raises_malformed_on_missing_key(self):

--- a/tests/test_backend_memcache.py
+++ b/tests/test_backend_memcache.py
@@ -19,6 +19,7 @@ import uuid
 import memcache
 
 from keystone.common import utils
+from keystone import exception
 from keystone.openstack.common import timeutils
 from keystone import test
 from keystone.token.backends import memcache as token_memcache
@@ -96,3 +97,7 @@ class MemcacheToken(test.TestCase, test_backend.TokenTests):
     def test_list_tokens_unicode_user_id(self):
         user_id = unicode(uuid.uuid4().hex)
         self.token_api.list_tokens(user_id)
+
+    def test_flush_expired_token(self):
+        with self.assertRaises(exception.NotImplemented):
+            self.token_api.flush_expired_tokens()


### PR DESCRIPTION
Creates a cli entry 'token_flush' which removes all expired tokens.

Fixes: bug 1032633
Implements: blueprint keystone-manage-token-flush
Change-Id: I47eab99b577ff9e9ee74fee08e18fd07c4af5aad

Conflicts:
    doc/source/man/keystone-manage.rst
    keystone/cli.py
    keystone/token/core.py
